### PR TITLE
esn-dav-import-client#5: Now allows passing esnApiClient which is an instance of Client when constructing ESNDavImportClient

### DIFF
--- a/src/ESNDavImportClient.js
+++ b/src/ESNDavImportClient.js
@@ -1,24 +1,23 @@
-import { Client, davImportApi } from 'esn-api-client/src';
+import Client from 'esn-api-client/src/Client';
+import davImportApi from 'esn-api-client/src/api/dav-import';
 
 export default class ESNDavImportClient {
   /**
    * @constructor
-   * @param {Function} uploadFile the function to upload file
-   * @param {String} OPENPAAS_URL the deployed URL for OpenPaaS server
+   * @param {Object} options An options object that contains:
+   * @param {Function} options.esnApiClient the instance of Client to communicate with ESN's Backend APIs
+   * @param {Function} options.uploadFile the function to upload file
    */
-  constructor(uploadFile, OPENPAAS_URL) {
+  constructor({ esnApiClient, uploadFile }) {
+    if (!(esnApiClient instanceof Client)) {
+      throw new Error('esnApiClient is required and must be an instance of Client');
+    }
+
     if (typeof uploadFile !== 'function') {
       throw new Error('uploadFile is required and must be a function');
     }
 
-    if (!OPENPAAS_URL) {
-      throw new Error('OPENPAAS_URL is required');
-    }
-
     this.uploadFile = uploadFile;
-
-    const esnApiClient = new Client({ baseURL: `${OPENPAAS_URL}/linagora.esn.dav.import/api` });
-
     this.davImportApi = davImportApi(esnApiClient);
   }
 

--- a/test/__mocks__/esn-api-client/src/Client.js
+++ b/test/__mocks__/esn-api-client/src/Client.js
@@ -1,0 +1,1 @@
+export default class Client {}

--- a/test/src/ESNDavImportClient.spec.js
+++ b/test/src/ESNDavImportClient.spec.js
@@ -1,31 +1,53 @@
+import * as davImportApi from 'esn-api-client/src/api/dav-import';
+import Client from 'esn-api-client/src/Client';
 import { ESNDavImportClient } from '../../src';
 
-const OPENPAAS_URL = 'http://esn';
+jest.mock('esn-api-client/src/Client');
+
+const davImportApiSpy = jest.spyOn(davImportApi, 'default');
 
 describe('The ESNDavImportClient class', () => {
   describe('The constructor method', () => {
+    test('should throw error if esnApiClient is not provided', () => {
+      expect(() => new ESNDavImportClient({})).toThrow(/esnApiClient is required and must be an instance of Client/);
+    });
+
+    test('should throw error if esnApiClient is not an instance of Client', () => {
+      const esnApiClient = new Date();
+
+      expect(() => new ESNDavImportClient({ esnApiClient })).toThrow(/esnApiClient is required and must be an instance of Client/);
+    });
+
     test('should throw error if the uploadFile method is not provided', () => {
-      expect(() => new ESNDavImportClient()).toThrow(/uploadFile is required and must be a function/);
+      const esnApiClient = new Client();
+
+      expect(() => new ESNDavImportClient({ esnApiClient })).toThrow(/uploadFile is required and must be a function/);
     });
 
     test('should throw error if the uploadFile is not a function', () => {
+      const esnApiClient = new Client();
       const uploadFile = 'not a function';
 
-      expect(() => new ESNDavImportClient(uploadFile)).toThrow(/uploadFile is required and must be a function/);
+      expect(() => new ESNDavImportClient({ esnApiClient, uploadFile })).toThrow(/uploadFile is required and must be a function/);
     });
 
-    test('should throw error if the OPENPAAS_URL is not provided', () => {
+    test('should set the instance properties correctly if esnApiClient and uploadFile are valid', () => {
+      const esnApiClient = new Client();
       const uploadFile = () => {};
 
-      expect(() => new ESNDavImportClient(uploadFile)).toThrow(/OPENPAAS_URL is required/);
+      const esnDavImportClient = new ESNDavImportClient({ esnApiClient, uploadFile });
+
+      expect(esnDavImportClient.uploadFile).toBe(uploadFile);
+      expect(davImportApiSpy.mock.calls[0][0]).toBe(esnApiClient);
     });
   });
 
   describe('The importFromFile method', () => {
     test('should reject if failed to upload file', done => {
       const errorMessage = 'something wrong';
+      const esnApiClient = new Client();
       const uploadFile = jest.fn().mockResolvedValue(Promise.reject(new Error(errorMessage)));
-      const esnDavImportClient = new ESNDavImportClient(uploadFile, OPENPAAS_URL);
+      const esnDavImportClient = new ESNDavImportClient({ esnApiClient, uploadFile });
       const file = { foo: 'bar' };
       const target = '/target/path';
 
@@ -46,8 +68,9 @@ describe('The ESNDavImportClient class', () => {
     test('should reject if failed to import from file', done => {
       const errorMessage = 'something wrong';
       const fileId = 'fileId';
+      const esnApiClient = new Client();
       const uploadFile = jest.fn().mockResolvedValue(Promise.resolve(fileId));
-      const esnDavImportClient = new ESNDavImportClient(uploadFile, OPENPAAS_URL);
+      const esnDavImportClient = new ESNDavImportClient({ esnApiClient, uploadFile });
       const file = { foo: 'bar' };
       const target = '/target/path';
 
@@ -67,8 +90,9 @@ describe('The ESNDavImportClient class', () => {
 
     test('should call the davImportClient with correct params to import from file', done => {
       const fileId = 'fileId';
+      const esnApiClient = new Client();
       const uploadFile = jest.fn().mockResolvedValue(Promise.resolve(fileId));
-      const esnDavImportClient = new ESNDavImportClient(uploadFile, OPENPAAS_URL);
+      const esnDavImportClient = new ESNDavImportClient({ esnApiClient, uploadFile });
       const file = { foo: 'bar' };
       const target = '/target/path';
 


### PR DESCRIPTION
Partially resolves #5. Please also refer to these PRs:

- https://github.com/OpenPaaS-Suite/esn-frontend-calendar/pull/102
- https://github.com/OpenPaaS-Suite/esn-frontend-contacts/pull/67
- https://github.com/OpenPaaS-Suite/esn-api-client/pull/15